### PR TITLE
Bug fix in conn, pr

### DIFF
--- a/graphalytics-platforms-graphmat-platform/src/main/c/conn.cpp
+++ b/graphalytics-platforms-graphmat-platform/src/main/c/conn.cpp
@@ -64,7 +64,7 @@ class WeaklyConnectedComponents: public GraphProgram<msg_type, reduce_type, vert
         }
 
         void apply(const reduce_type& total, vertex_value_type& vertex) {
-            vertex.prev = vertex.prev;
+            vertex.prev = vertex.curr;
             vertex.curr = min(vertex.curr, total);
         }
 };

--- a/graphalytics-platforms-graphmat-platform/src/main/c/pr.cpp
+++ b/graphalytics-platforms-graphmat-platform/src/main/c/pr.cpp
@@ -22,10 +22,12 @@ struct vertex_value_type {
     public:
         score_type score;
         int out_degree;
+        int in_degree;
 
         vertex_value_type() {
             score = 0.0;
             out_degree = 0;
+            in_degree = 0;
         }
 
         bool operator!=(const vertex_value_type& other) const {
@@ -64,13 +66,38 @@ class DegreeProgram: public GraphProgram<int, int, vertex_value_type> {
 
 };
 
+class InDegreeProgram: public GraphProgram<int, int, vertex_value_type> {
+    public:
+        InDegreeProgram() {
+            order = OUT_EDGES;
+            activity = ALL_VERTICES;
+        }
+
+        bool send_message(const vertex_value_type& vertex, int& msg) const {
+            msg = 1;
+            return true;
+        }
+
+        void process_message(const int& msg, const int edge, const vertex_value_type& vertex, int& result) const {
+            result = msg;
+        }
+
+        void reduce_function(int& total, const int& partial) const {
+            total += partial;
+        }
+
+        void apply(const int& total, vertex_value_type& vertex) {
+            vertex.in_degree = total;
+        }
+
+};
 
 class PageRankProgram: public GraphProgram<msg_type, reduce_type, vertex_value_type> {
     public:
         double damping_factor;
         int nvertices;
         score_type dangling_sum;
-        atomic<score_type> next_dangling_sum;
+        Graph<vertex_value_type>* graph_ref; //pointer to the graph being operated on.
 
         PageRankProgram(double damping_factor, int nvertices) {
             order = OUT_EDGES;
@@ -81,6 +108,9 @@ class PageRankProgram: public GraphProgram<msg_type, reduce_type, vertex_value_t
 
         void set_dangling(int ndangling) {
             this->dangling_sum = ndangling / score_type(nvertices);
+        }
+        void set_graph_pointer(Graph<vertex_value_type> *G) {
+          graph_ref = G;
         }
 
         bool send_message(const vertex_value_type& vertex, msg_type& msg) const {
@@ -99,20 +129,24 @@ class PageRankProgram: public GraphProgram<msg_type, reduce_type, vertex_value_t
         void apply(const reduce_type& total, vertex_value_type& vertex) {
             vertex.score = (1 - damping_factor) / nvertices
                          + damping_factor * (total + dangling_sum / nvertices);
-
-            if (vertex.out_degree == 0) {
-                score_type a, b;
-
-                do {
-                    a = next_dangling_sum.load();
-                    b = a + vertex.score;
-                } while(!next_dangling_sum.compare_exchange_weak(a, b));
-            }
         }
 
         void do_every_iteration(int it) {
-            dangling_sum = next_dangling_sum.load();
-            next_dangling_sum.store(0.0);
+            //Fix vertices with 0 in and out degrees here. 
+            //We have a pointer to the graph being operated on. 
+
+            score_type next_dangling_sum = 0.0;
+            #pragma omp parallel for reduction(+:next_dangling_sum)
+            for (size_t i = 0; i < nvertices; i++) {
+              if (graph_ref->vertexproperty[i].out_degree == 0) {
+                next_dangling_sum += graph_ref->vertexproperty[i].score;
+              }
+              if (graph_ref->vertexproperty[i].in_degree == 0) {
+                graph_ref->vertexproperty[i].score = (1 - damping_factor + 
+                                                      damping_factor*dangling_sum) / nvertices;
+              }
+            }
+            dangling_sum = next_dangling_sum;
         }
 };
 
@@ -154,6 +188,8 @@ int main(int argc, char *argv[]) {
 
     DegreeProgram deg_prog;
     auto ctx = graph_program_init(deg_prog, graph);
+    InDegreeProgram in_deg_prog;
+    auto ctx_in = graph_program_init(in_deg_prog, graph);
 
     PageRankProgram pr_prog(damping_factor, graph.nvertices);
     auto ctx2 = graph_program_init(pr_prog, graph);
@@ -165,6 +201,7 @@ int main(int argc, char *argv[]) {
 
     timer_next("run algorithm 1 (count degree)");
     run_graph_program(&deg_prog, graph, 1, &ctx);
+    run_graph_program(&in_deg_prog, graph, 1, &ctx_in);
 
     timer_next("run algorithm 2 (compute PageRank)");
     int ndangling = 0;
@@ -175,6 +212,8 @@ int main(int argc, char *argv[]) {
     }
 
     pr_prog.set_dangling(ndangling);
+    pr_prog.set_graph_pointer(&graph);
+
     run_graph_program(&pr_prog, graph, niterations, &ctx2);
 
 #ifdef GRANULA
@@ -195,6 +234,7 @@ int main(int argc, char *argv[]) {
 
     timer_next("deinitialize engine");
     graph_program_clear(ctx);
+    graph_program_clear(ctx_in);
     graph_program_clear(ctx2);
 
     timer_end();


### PR DESCRIPTION
Simple bug fix in conn.
For pagerank, this fix avoids the use of atomic operations and instead scans the vertices once every iteration and updates zero in-degree vertices and dangling sum. This requires keeping track of the in-degrees as well as out-degrees.
